### PR TITLE
reverse artifacts key/value relation, enabling multiple destinations for a given source

### DIFF
--- a/add_package.rb
+++ b/add_package.rb
@@ -48,7 +48,7 @@ def fetch_artifacts(artifacts)
 
   # connect to s3 here
   @s3 ||= Aws::S3::Client.new(:region => ENV["AWS_REGION"])
-  artifacts.each do |source, destination|
+  artifacts.each do |destination, source|
     destination_dir = File.dirname(destination)
     FileUtils.mkdir_p(destination_dir)
 
@@ -156,7 +156,7 @@ PLATFORMS.each do |name, data|
         end
 
         source_path = File.join(source_path, filename, filename)
-        artifacts[source_path] = destination_path
+        artifacts[destination_path] = source_path
 
         case name
         when "debian", "ubuntu"


### PR DESCRIPTION
We added "precise" and "sensu" as codenames for 12.04 but after this change only
"sensu" has an unstable channel. Seems to be due to using "source_path" as the
key under artifacts hash. Reversing the relation, that is, making
"destination_path" the key with "source_path" as the value will allow us to have
multiple local destinations for a given artifact source_path.