### PR TITLE
Remove i386 arch variant from Freebsd 10 platform

### DIFF
--- a/platforms.rb
+++ b/platforms.rb
@@ -38,7 +38,7 @@ PLATFORMS = {
     "base_path" => "/srv/freebsd",
     "versions" => {
       "10" => {
-        "architectures" => ["i386", "amd64"]
+        "architectures" => ["amd64"]
       },
       "11" => {
         "architectures" => ["amd64"]


### PR DESCRIPTION
Per sensu-omnibus readme we aren't building this variant, so lets remove it.