### PR TITLE
expand platforms to include windows 2008r2 variant

### DIFF
--- a/add_package.rb
+++ b/add_package.rb
@@ -276,6 +276,16 @@ platforms.each do |platform, data|
         commands << "cd #{cwd} && pkg repo ."
       end
     end
+  when "windows"
+    cwd = File.join(base_path, "msi", channel)
+    {
+      "2008r2" => ["2008", "2003"],
+      "2012r2" => ["2012"]
+    }.each_pair do |source, links|
+      links.each do |link|
+        commands << "cd #{cwd} && ln -sfv #{source} #{link}"
+      end
+    end
   end
 end
 

--- a/add_package.rb
+++ b/add_package.rb
@@ -280,7 +280,7 @@ platforms.each do |platform, data|
     cwd = File.join(base_path, "msi", channel)
     {
       "2008r2" => ["2008", "2003"],
-      "2012r2" => ["2012"]
+      "2012r2" => ["2012", "2016"]
     }.each_pair do |source, links|
       links.each do |link|
         commands << "cd #{cwd} && ln -sfv #{source} #{link}"

--- a/platforms.rb
+++ b/platforms.rb
@@ -95,6 +95,9 @@ PLATFORMS = {
     "versions" => {
       "2012r2" => {
         "architectures" => ["i386", "x86_64"]
+      },
+      "2008r2" => {
+        "architectures" => ["i386", "x86_64"]
       }
     }
   }


### PR DESCRIPTION
This change will pull in Windows 2008r2 artifacts from S3 and create symlinks. Symlinks should map to real directories as follows:

2008, 2003 -> 2008r2
2012 -> 2012r2